### PR TITLE
fix: mark variables in libprojectroot.h as extern

### DIFF
--- a/libprojectroot.h
+++ b/libprojectroot.h
@@ -9,8 +9,8 @@
 #define N_CANDIDATES 26
 #define BUFFER_SIZE 1024
 
-int weight_mode_on;
-int verbose_on;
+extern int weight_mode_on;
+extern int verbose_on;
 
 int is_project_root(char* cdt);
 char* find_project_root_weighted(char* cwd);


### PR DESCRIPTION
Not sure if you are still looking after this project. But it does scratch an itch I had and I was not able to build it on my machine unless changing the definition of `verbose_on` and `weight_mode_on` to "extern" in `libprojectroot.h`.

I'm by no means a C developer so it may be the wrong thing to do. But here goes!